### PR TITLE
Remove functions that install libraries

### DIFF
--- a/load_libraries.R
+++ b/load_libraries.R
@@ -1,12 +1,3 @@
-all.libraries <- c('leaflet', 'maps','mapproj',
-                   'maptools','RColorBrewer', 'shiny',
-                   'shinyjs','shinythemes','rgdal',
-                   'sp', 'raster', 'mapview', 'automap',
-                   'dygraphs','xts', 'plotly', 'lubridate')
-
-if(length(new.pkgs <- setdiff(all.libraries, 
-                              rownames(installed.packages())))) install.packages(new.pkgs)
-
 library(leaflet)
 library(maps)
 library(mapproj)


### PR DESCRIPTION
Checked with Craig, and it looks like it's better to leave it to IT/Ops to handle package installation. So essentially, the app will run assuming the libraries were previously - and correctly - installed.