### PR TITLE
Create a variable and discard the elementID to solve warning messages in console from plotly

### DIFF
--- a/server.R
+++ b/server.R
@@ -203,7 +203,7 @@ server <- function(input,output,session) {
     )
 
     ## creating the plotly line plot.
-    plot_ly(data_ecan) %>%
+    p <- plot_ly(data_ecan) %>%
       add_lines(x = ~DateTime, y = ~PM10, name = "PM10", color = I("#F39C12")) %>%
       add_lines(x = ~DateTime, y = ~u, name = "WSpeed",  yaxis = "y2", color =I("#2471A3")) %>%
       layout(
@@ -216,6 +216,8 @@ server <- function(input,output,session) {
         xaxis = list(range = c(input$timeRange -129600,input$timeRange +129600),
                      rangeslider = list(type = "date"), title = "")) %>%
       config(displayModeBar = FALSE)
+	p$elementId <- NULL
+	p
   })
   
   ### datetime output: #####


### PR DESCRIPTION
A known issue in plotly/shiny, not too sure whether it was fixed/released but not available to all R version, or not yet fixed.

See https://github.com/ropensci/plotly/issues/985 for more.

We have one warning in the application for the `xlim` not set in the barplot. But we have a lot of warnings repeating in short time.