### PR TITLE
Add packrat

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,0 +1,3 @@
+#### -- Packrat Autoloader (version 0.4.9-2) -- ####
+source("packrat/init.R")
+#### -- End Packrat Autoloader -- ####

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 Data/*
 *.RData
 niwa-logo.jpg
+packrat/lib*/
+packrat/src/

--- a/packrat/init.R
+++ b/packrat/init.R
@@ -1,0 +1,226 @@
+local({
+
+  ## Helper function to get the path to the library directory for a
+  ## given packrat project.
+  getPackratLibDir <- function(projDir = NULL) {
+    path <- file.path("packrat", "lib", R.version$platform, getRversion())
+
+    if (!is.null(projDir)) {
+
+      ## Strip trailing slashes if necessary
+      projDir <- sub("/+$", "", projDir)
+
+      ## Only prepend path if different from current working dir
+      if (!identical(normalizePath(projDir), normalizePath(getwd())))
+        path <- file.path(projDir, path)
+    }
+
+    path
+  }
+
+  ## Ensure that we set the packrat library directory relative to the
+  ## project directory. Normally, this should be the working directory,
+  ## but we also use '.rs.getProjectDirectory()' if necessary (e.g. we're
+  ## rebuilding a project while within a separate directory)
+  libDir <- if (exists(".rs.getProjectDirectory"))
+    getPackratLibDir(.rs.getProjectDirectory())
+  else
+    getPackratLibDir()
+
+  ## Unload packrat in case it's loaded -- this ensures packrat _must_ be
+  ## loaded from the private library. Note that `requireNamespace` will
+  ## succeed if the package is already loaded, regardless of lib.loc!
+  if ("packrat" %in% loadedNamespaces())
+    try(unloadNamespace("packrat"), silent = TRUE)
+
+  if (suppressWarnings(requireNamespace("packrat", quietly = TRUE, lib.loc = libDir))) {
+
+    # Check 'print.banner.on.startup' -- when NA and RStudio, don't print
+    print.banner <- packrat::get_opts("print.banner.on.startup")
+    if (print.banner == "auto" && is.na(Sys.getenv("RSTUDIO", unset = NA))) {
+      print.banner <- TRUE
+    } else {
+      print.banner <- FALSE
+    }
+    return(packrat::on(print.banner = print.banner))
+  }
+
+  ## Escape hatch to allow RStudio to handle bootstrapping. This
+  ## enables RStudio to provide print output when automagically
+  ## restoring a project from a bundle on load.
+  if (!is.na(Sys.getenv("RSTUDIO", unset = NA)) &&
+      is.na(Sys.getenv("RSTUDIO_PACKRAT_BOOTSTRAP", unset = NA))) {
+    Sys.setenv("RSTUDIO_PACKRAT_BOOTSTRAP" = "1")
+    setHook("rstudio.sessionInit", function(...) {
+      # Ensure that, on sourcing 'packrat/init.R', we are
+      # within the project root directory
+      if (exists(".rs.getProjectDirectory")) {
+        owd <- getwd()
+        setwd(.rs.getProjectDirectory())
+        on.exit(setwd(owd), add = TRUE)
+      }
+      source("packrat/init.R")
+    })
+    return(invisible(NULL))
+  }
+
+  ## Bootstrapping -- only performed in interactive contexts,
+  ## or when explicitly asked for on the command line
+  if (interactive() || "--bootstrap-packrat" %in% commandArgs(TRUE)) {
+
+    needsRestore <- "--bootstrap-packrat" %in% commandArgs(TRUE)
+
+    message("Packrat is not installed in the local library -- ",
+            "attempting to bootstrap an installation...")
+
+    ## We need utils for the following to succeed -- there are calls to functions
+    ## in 'restore' that are contained within utils. utils gets loaded at the
+    ## end of start-up anyhow, so this should be fine
+    library("utils", character.only = TRUE)
+
+    ## Install packrat into local project library
+    packratSrcPath <- list.files(full.names = TRUE,
+                                 file.path("packrat", "src", "packrat")
+    )
+
+    ## No packrat tarballs available locally -- try some other means of installation
+    if (!length(packratSrcPath)) {
+
+      message("> No source tarball of packrat available locally")
+
+      ## There are no packrat sources available -- try using a version of
+      ## packrat installed in the user library to bootstrap
+      if (requireNamespace("packrat", quietly = TRUE) && packageVersion("packrat") >= "0.2.0.99") {
+        message("> Using user-library packrat (",
+                packageVersion("packrat"),
+                ") to bootstrap this project")
+      }
+
+      ## Couldn't find a user-local packrat -- try finding and using devtools
+      ## to install
+      else if (requireNamespace("devtools", quietly = TRUE)) {
+        message("> Attempting to use devtools::install_github to install ",
+                "a temporary version of packrat")
+        library(stats) ## for setNames
+        devtools::install_github("rstudio/packrat")
+      }
+
+      ## Try downloading packrat from CRAN if available
+      else if ("packrat" %in% rownames(available.packages())) {
+        message("> Installing packrat from CRAN")
+        install.packages("packrat")
+      }
+
+      ## Fail -- couldn't find an appropriate means of installing packrat
+      else {
+        stop("Could not automatically bootstrap packrat -- try running ",
+             "\"'install.packages('devtools'); devtools::install_github('rstudio/packrat')\"",
+             "and restarting R to bootstrap packrat.")
+      }
+
+      # Restore the project, unload the temporary packrat, and load the private packrat
+      if (needsRestore)
+        packrat::restore(prompt = FALSE, restart = TRUE)
+
+      ## This code path only reached if we didn't restart earlier
+      unloadNamespace("packrat")
+      requireNamespace("packrat", lib.loc = libDir, quietly = TRUE)
+      return(packrat::on())
+
+    }
+
+    ## Multiple packrat tarballs available locally -- try to choose one
+    ## TODO: read lock file and infer most appropriate from there; low priority because
+    ## after bootstrapping packrat a restore should do the right thing
+    if (length(packratSrcPath) > 1) {
+      warning("Multiple versions of packrat available in the source directory;",
+              "using packrat source:\n- ", shQuote(packratSrcPath))
+      packratSrcPath <- packratSrcPath[[1]]
+    }
+
+
+    lib <- file.path("packrat", "lib", R.version$platform, getRversion())
+    if (!file.exists(lib)) {
+      dir.create(lib, recursive = TRUE)
+    }
+
+    message("> Installing packrat into project private library:")
+    message("- ", shQuote(lib))
+
+    surround <- function(x, with) {
+      if (!length(x)) return(character())
+      paste0(with, x, with)
+    }
+
+
+    ## Invoke install.packages() in clean R session
+    peq <- function(x, y) paste(x, y, sep = " = ")
+    installArgs <- c(
+      peq("pkgs", surround(packratSrcPath, with = "'")),
+      peq("lib", surround(lib, with = "'")),
+      peq("repos", "NULL"),
+      peq("type", surround("source", with = "'"))
+    )
+
+    fmt <- "utils::install.packages(%s)"
+    installCmd <- sprintf(fmt, paste(installArgs, collapse = ", "))
+
+    ## Write script to file (avoid issues with command line quoting
+    ## on R 3.4.3)
+    installFile <- tempfile("packrat-bootstrap", fileext = ".R")
+    writeLines(installCmd, con = installFile)
+    on.exit(unlink(installFile), add = TRUE)
+
+    fullCmd <- paste(
+      surround(file.path(R.home("bin"), "R"), with = "\""),
+      "--vanilla",
+      "--slave",
+      "-f",
+      surround(installFile, with = "\"")
+    )
+    system(fullCmd)
+
+    ## Tag the installed packrat so we know it's managed by packrat
+    ## TODO: should this be taking information from the lockfile? this is a bit awkward
+    ## because we're taking an un-annotated packrat source tarball and simply assuming it's now
+    ## an 'installed from source' version
+
+    ## -- InstallAgent -- ##
+    installAgent <- "InstallAgent: packrat 0.4.9-2"
+
+    ## -- InstallSource -- ##
+    installSource <- "InstallSource: source"
+
+    packratDescPath <- file.path(lib, "packrat", "DESCRIPTION")
+    DESCRIPTION <- readLines(packratDescPath)
+    DESCRIPTION <- c(DESCRIPTION, installAgent, installSource)
+    cat(DESCRIPTION, file = packratDescPath, sep = "\n")
+
+    # Otherwise, continue on as normal
+    message("> Attaching packrat")
+    library("packrat", character.only = TRUE, lib.loc = lib)
+
+    message("> Restoring library")
+    if (needsRestore)
+      packrat::restore(prompt = FALSE, restart = FALSE)
+
+    # If the environment allows us to restart, do so with a call to restore
+    restart <- getOption("restart")
+    if (!is.null(restart)) {
+      message("> Packrat bootstrap successfully completed. ",
+              "Restarting R and entering packrat mode...")
+      return(restart())
+    }
+
+    # Callers (source-erers) can define this hidden variable to make sure we don't enter packrat mode
+    # Primarily useful for testing
+    if (!exists(".__DONT_ENTER_PACKRAT_MODE__.") && interactive()) {
+      message("> Packrat bootstrap successfully completed. Entering packrat mode...")
+      packrat::on()
+    }
+
+    Sys.unsetenv("RSTUDIO_PACKRAT_BOOTSTRAP")
+
+  }
+
+})

--- a/packrat/packrat.lock
+++ b/packrat/packrat.lock
@@ -1,0 +1,544 @@
+PackratFormat: 1.4
+PackratVersion: 0.4.9.2
+RVersion: 3.4.4
+Repos: CRAN=https://cloud.r-project.org
+
+Package: BH
+Source: CRAN
+Version: 1.65.0-1
+Hash: 95f62be4d6916aae14a310a8b56a6475
+
+Package: DBI
+Source: CRAN
+Version: 0.7
+Hash: 1ab72df487f06ad5f0de05446cdd4bd6
+
+Package: FNN
+Source: CRAN
+Version: 1.1
+Hash: c057509dc46a5303c20514f256f79a5e
+
+Package: R.methodsS3
+Source: CRAN
+Version: 1.7.1
+Hash: 99f841ba1614c005e6672c5fb01b352a
+
+Package: R.oo
+Source: CRAN
+Version: 1.21.0
+Hash: d155101c5eb87d728d43e23c6902f4d5
+Requires: R.methodsS3
+
+Package: R.utils
+Source: CRAN
+Version: 2.6.0
+Hash: 7d46f5c3a914a82db092e1404d6ae624
+Requires: R.methodsS3, R.oo
+
+Package: R6
+Source: CRAN
+Version: 2.2.2
+Hash: b2366cd9d2f3851a5704b4e192b985c2
+
+Package: RColorBrewer
+Source: CRAN
+Version: 1.1-2
+Hash: c0d56cd15034f395874c870141870c25
+
+Package: Rcpp
+Source: CRAN
+Version: 0.12.14
+Hash: f9a2a481350397e53b0768bf488329cd
+
+Package: assertthat
+Source: CRAN
+Version: 0.2.0
+Hash: e8805df54c65ac96d50235c44a82615c
+
+Package: automap
+Source: CRAN
+Version: 1.0-14
+Hash: e31a3b38f3190f8fb9badc76d70e2f6e
+Requires: gstat, reshape, sp
+
+Package: base64enc
+Source: CRAN
+Version: 0.1-3
+Hash: c590d29e555926af053055e23ee79efb
+
+Package: bindr
+Source: CRAN
+Version: 0.1
+Hash: e3a02070cf705d3ad1c5af1635a515a3
+
+Package: bindrcpp
+Source: CRAN
+Version: 0.2
+Hash: 7f7dcd1dc351f84798fd3dc4eb8a0e78
+Requires: Rcpp, bindr, plogr
+
+Package: brew
+Source: CRAN
+Version: 1.0-6
+Hash: 931f9972deae0f205e1c78a51f33149b
+
+Package: classInt
+Source: CRAN
+Version: 0.1-24
+Hash: 0edecb3f0021a4ef80f45bd9edae0c71
+Requires: e1071
+
+Package: cli
+Source: CRAN
+Version: 1.0.0
+Hash: f4239f89feb7ddc65821e4514e9734ae
+Requires: assertthat, crayon
+
+Package: colorspace
+Source: CRAN
+Version: 1.3-2
+Hash: 0bf8618b585fa98eb23414cd3ab95118
+
+Package: crayon
+Source: CRAN
+Version: 1.3.4
+Hash: ff2840dd9b0d563fc80377a5a45510cd
+
+Package: crosstalk
+Source: CRAN
+Version: 1.0.0
+Hash: c13adea5906fbe2becfcb5f843b26749
+Requires: R6, ggplot2, htmltools, jsonlite, lazyeval, shiny
+
+Package: curl
+Source: CRAN
+Version: 3.1
+Hash: 877149b42d479b93ab15d5cef46c0f1b
+
+Package: data.table
+Source: CRAN
+Version: 1.10.4-3
+Hash: 3c270a59ca3298aba8df3c1ae3bbea19
+
+Package: debugme
+Source: CRAN
+Version: 1.1.0
+Hash: c233690edd9fa17a63f7c8d83c1ca153
+Requires: crayon
+
+Package: dichromat
+Source: CRAN
+Version: 2.0-0
+Hash: 08eed0c80510af29bb15f840ccfe37ce
+
+Package: digest
+Source: CRAN
+Version: 0.6.13
+Hash: cfce0bc7ed5ba0cdc47182698fae1d24
+
+Package: dplyr
+Source: CRAN
+Version: 0.7.4
+Hash: e1c300a22e22086568531c9d0c93bafc
+Requires: BH, R6, Rcpp, assertthat, bindrcpp, glue, magrittr,
+    pkgconfig, plogr, rlang, tibble
+
+Package: dygraphs
+Source: CRAN
+Version: 1.1.1.4
+Hash: 6c0c428f37a8923a337e1af157f63839
+Requires: htmltools, htmlwidgets, magrittr, xts, zoo
+
+Package: e1071
+Source: CRAN
+Version: 1.6-8
+Hash: 20320ec66d4dc608654769145b7c624a
+
+Package: foreach
+Source: CRAN
+Version: 1.4.4
+Hash: 4df5ab2c8c35382dacab75d414da6748
+Requires: iterators
+
+Package: gdalUtils
+Source: CRAN
+Version: 2.0.1.7
+Hash: 598915498d88cf50d2072e2db5841189
+Requires: R.utils, foreach, raster, rgdal, sp
+
+Package: ggplot2
+Source: CRAN
+Version: 2.2.1
+Hash: 46e5cb78836848aa44655e577433f54b
+Requires: digest, gtable, lazyeval, plyr, reshape2, scales, tibble
+
+Package: glue
+Source: CRAN
+Version: 1.2.0
+Hash: 381e42baedecc633c0e547a0c7ca9de7
+
+Package: gridExtra
+Source: CRAN
+Version: 2.3
+Hash: fa977bc1aab5588a08123b10ceb1ad3d
+Requires: gtable
+
+Package: gstat
+Source: CRAN
+Version: 1.1-5
+Hash: 0ef4156b7630806ffba9aef1d1fb4b40
+Requires: FNN, sp, spacetime, zoo
+
+Package: gtable
+Source: CRAN
+Version: 0.2.0
+Hash: cd78381a9d3fea966ac39bd0daaf5554
+
+Package: hexbin
+Source: CRAN
+Version: 1.27.1
+Hash: 378383b2c37556649fd6b2ee0be7e2a5
+
+Package: htmltools
+Source: CRAN
+Version: 0.3.6
+Hash: 10db2fe4e1ac6057e5555db165a0d870
+Requires: Rcpp, digest
+
+Package: htmlwidgets
+Source: CRAN
+Version: 0.9
+Hash: 7514f6ea9f3bef6d9b6c945095275302
+Requires: htmltools, jsonlite, yaml
+
+Package: httpuv
+Source: CRAN
+Version: 1.3.5
+Hash: ecd2d1c0cac94fe968398551b57d7fb2
+Requires: Rcpp
+
+Package: httr
+Source: CRAN
+Version: 1.3.1
+Hash: 2d32e01e53d532c812052e27a1021441
+Requires: R6, curl, jsonlite, mime, openssl
+
+Package: intervals
+Source: CRAN
+Version: 0.15.1
+Hash: 26e23563c50548f8588a112a4baaa297
+
+Package: iterators
+Source: CRAN
+Version: 1.0.9
+Hash: c2dc1341675d2508c180221949e40e98
+
+Package: jsonlite
+Source: CRAN
+Version: 1.5
+Hash: 9c51936d8dd00b2f1d4fe9d10499694c
+
+Package: labeling
+Source: CRAN
+Version: 0.3
+Hash: ecf589b42cd284b03a4beb9665482d3e
+
+Package: lazyeval
+Source: CRAN
+Version: 0.2.1
+Hash: 88926ad9c43581fd0822a37c8ed09f05
+
+Package: leaflet
+Source: CRAN
+Version: 1.1.0
+Hash: 25f9a891535d490e22c4e200bf303362
+Requires: RColorBrewer, base64enc, crosstalk, htmltools, htmlwidgets,
+    magrittr, markdown, png, raster, scales, sp, viridis
+
+Package: lubridate
+Source: CRAN
+Version: 1.7.1
+Hash: 1933c3cc6c3b49091ec4e287e65725fc
+Requires: Rcpp, stringr
+
+Package: magrittr
+Source: CRAN
+Version: 1.5
+Hash: bdc4d48c3135e8f3b399536ddf160df4
+
+Package: mapproj
+Source: CRAN
+Version: 1.2-5
+Hash: c1a918323e5d768ca1a5f91eea5571af
+Requires: maps
+
+Package: maps
+Source: CRAN
+Version: 3.2.0
+Hash: 086a0f4e41bf42749d8737e9407a4853
+
+Package: maptools
+Source: CRAN
+Version: 0.9-2
+Hash: 2dfbad6ef57f83a91e4e9d4ccc0807cd
+Requires: sp
+
+Package: mapview
+Source: CRAN
+Version: 2.2.0
+Hash: 19ea6b73491028db28efbf5d0af6df55
+Requires: Rcpp, base64enc, brew, gdalUtils, htmltools, htmlwidgets,
+    leaflet, png, raster, satellite, scales, sf, sp, viridisLite,
+    webshot
+
+Package: markdown
+Source: CRAN
+Version: 0.8
+Hash: 045d7c594d503b41f1c28946d076c8aa
+Requires: mime
+
+Package: mime
+Source: CRAN
+Version: 0.5
+Hash: 463550cf44fb6f0a2359368f42eebe62
+
+Package: miniUI
+Source: CRAN
+Version: 0.1.1
+Hash: e85626581f80b1fe6c92a96ec348efc5
+Requires: htmltools, shiny
+
+Package: munsell
+Source: CRAN
+Version: 0.4.3
+Hash: f96d896947fcaf9b6d0074002e9f4f9d
+Requires: colorspace
+
+Package: openssl
+Source: CRAN
+Version: 0.9.9
+Hash: 3858537ac10388a5db1687450908f257
+
+Package: packrat
+Source: CRAN
+Version: 0.4.9-2
+Hash: 47dbd4e04dcd01da02a2021203205cb1
+
+Package: pillar
+Source: CRAN
+Version: 1.0.1
+Hash: 4025a3ad006633faec49105185b99ad8
+Requires: cli, crayon, rlang, utf8
+
+Package: pkgconfig
+Source: CRAN
+Version: 2.0.1
+Hash: 0dda4a2654a22b36a715c2b0b6fbacac
+
+Package: plogr
+Source: CRAN
+Version: 0.1-1
+Hash: fb19215402e2d9f1c7f803dcaa806fc2
+
+Package: plotly
+Source: CRAN
+Version: 4.7.1
+Hash: 18d2de809bf346363cd4ee7a587d58bf
+Requires: RColorBrewer, base64enc, crosstalk, data.table, digest,
+    dplyr, ggplot2, hexbin, htmltools, htmlwidgets, httr, jsonlite,
+    lazyeval, magrittr, purrr, scales, tibble, tidyr, viridisLite
+
+Package: plyr
+Source: CRAN
+Version: 1.8.4
+Hash: 39dd3286b865c7b725d74c9a4c1b7931
+Requires: Rcpp
+
+Package: png
+Source: CRAN
+Version: 0.1-7
+Hash: 421d7d6e0fb4bd885ecbd909b6456b8b
+
+Package: processx
+Source: CRAN
+Version: 2.0.0.1
+Hash: cfb7e4911fb7451f16f812580571652f
+Requires: R6, assertthat, crayon, debugme
+
+Package: purrr
+Source: CRAN
+Version: 0.2.4
+Hash: a80b244ccd3fdb33a0ff2be3c50dd648
+Requires: magrittr, rlang, tibble
+
+Package: raster
+Source: CRAN
+Version: 2.6-7
+Hash: ced0b96f255bfb3dda67bb55e22d9c5b
+Requires: Rcpp, sp
+
+Package: reshape
+Source: CRAN
+Version: 0.8.7
+Hash: f026a2928c05063a8d0b2e29a129f9a0
+Requires: plyr
+
+Package: reshape2
+Source: CRAN
+Version: 1.4.3
+Hash: 8b30de99bcf5d40fa1e3be0809ecce8e
+Requires: Rcpp, plyr, stringr
+
+Package: rgdal
+Source: CRAN
+Version: 1.2-16
+Hash: 4deb14e47d05ec2b250c8f1a1b828bb5
+Requires: sp
+
+Package: rlang
+Source: CRAN
+Version: 0.1.6
+Hash: 8eb4b2dce38b8f663cb9364b28eaa76b
+
+Package: satellite
+Source: CRAN
+Version: 1.0.1
+Hash: 36a5215a23989b0e199c29999c593a4b
+Requires: Rcpp, plyr, raster
+
+Package: scales
+Source: CRAN
+Version: 0.5.0
+Hash: 77d3b989d0995d27c9b2fa7da4093f34
+Requires: R6, RColorBrewer, Rcpp, dichromat, labeling, munsell, plyr,
+    viridisLite
+
+Package: sf
+Source: CRAN
+Version: 0.5-5
+Hash: d66d4d01a4a8ebc3e4ca61af40a61808
+Requires: DBI, Rcpp, classInt, magrittr, units
+
+Package: shiny
+Source: CRAN
+Version: 1.0.5
+Hash: 4d47532a807122bfd6bc3818310f9d2e
+Requires: R6, digest, htmltools, httpuv, jsonlite, mime, sourcetools,
+    xtable
+
+Package: shinyjs
+Source: CRAN
+Version: 0.9.1
+Hash: 80334571084beac03513e51be8a35554
+Requires: digest, htmltools, jsonlite, miniUI, shiny
+
+Package: shinythemes
+Source: CRAN
+Version: 1.1.1
+Hash: d15f59eaa7a9a0668cea3af7f477820c
+Requires: shiny
+
+Package: sourcetools
+Source: CRAN
+Version: 0.1.6
+Hash: 226d56d7469587da40b0f96180e711b4
+
+Package: sp
+Source: CRAN
+Version: 1.2-5
+Hash: 355c8b47792e18a08da8708132f994e0
+
+Package: spacetime
+Source: CRAN
+Version: 1.2-1
+Hash: 59cc2726c6b0e76d073d21dd742b8dd4
+Requires: intervals, sp, xts, zoo
+
+Package: stringi
+Source: CRAN
+Version: 1.1.6
+Hash: 4430faf2bcbe1b8de0d9be55bcfdcc0b
+
+Package: stringr
+Source: CRAN
+Version: 1.2.0
+Hash: 25a86d7f410513ebb7c0bc6a5e16bdc3
+Requires: magrittr, stringi
+
+Package: tibble
+Source: CRAN
+Version: 1.4.1
+Hash: 2e61874117a0824203d426b51e8b365d
+Requires: crayon, pillar, rlang
+
+Package: tidyr
+Source: CRAN
+Version: 0.7.2
+Hash: fcc26b5be4f8c300b3a02300de6131bf
+Requires: Rcpp, dplyr, glue, magrittr, purrr, rlang, stringi, tibble,
+    tidyselect
+
+Package: tidyselect
+Source: CRAN
+Version: 0.2.3
+Hash: f734832478bdc63b43457f9a0bc5a056
+Requires: Rcpp, glue, purrr, rlang
+
+Package: udunits2
+Source: CRAN
+Version: 0.13
+Hash: 587587ec23c49271e0657fed726e7846
+
+Package: units
+Source: CRAN
+Version: 0.4-6
+Hash: 26637fde346198982175f763514832ff
+Requires: udunits2
+
+Package: utf8
+Source: CRAN
+Version: 1.1.2
+Hash: 0e3e2bd16e641598b11d9e9988f41738
+
+Package: viridis
+Source: CRAN
+Version: 0.4.0
+Hash: 5bdac1bcf74a10a7a96f82191f498ab7
+Requires: ggplot2, gridExtra, viridisLite
+
+Package: viridisLite
+Source: CRAN
+Version: 0.2.0
+Hash: 10f0c25af3dc84eaae10f5854f47efdb
+
+Package: webshot
+Source: CRAN
+Version: 0.5.0
+Hash: 5f3174d4a88c04e8f1a1fb1a7805fd4b
+Requires: jsonlite, magrittr, processx, withr
+
+Package: withr
+Source: CRAN
+Version: 2.1.1
+Hash: a86856ae0b4a7c3daf9a3ef0097a403b
+
+Package: xtable
+Source: CRAN
+Version: 1.8-2
+Hash: 7293235cfcc14cdff1ce7fd1a0212031
+
+Package: xts
+Source: CRAN
+Version: 0.10-1
+Hash: 3f666c7bfbb0795ef5ad07332761cee9
+Requires: zoo
+
+Package: yaml
+Source: CRAN
+Version: 2.1.16
+Hash: 784ea5d8302d4a81f166a32a33c10711
+
+Package: zoo
+Source: CRAN
+Version: 1.8-0
+Hash: df9711767f56f086e8a8d1f0fb926ff6

--- a/packrat/packrat.opts
+++ b/packrat/packrat.opts
@@ -1,0 +1,18 @@
+auto.snapshot: FALSE
+use.cache: FALSE
+print.banner.on.startup: auto
+vcs.ignore.lib: TRUE
+vcs.ignore.src: TRUE
+external.packages: 
+local.repos: 
+load.external.packages.on.startup: TRUE
+ignored.packages: 
+ignored.directories:
+    data
+    inst
+quiet.package.installation: TRUE
+snapshot.recommended.packages: FALSE
+snapshot.fields:
+    Imports
+    Depends
+    LinkingTo


### PR DESCRIPTION
Hey @ayushikachhara !

Learning packrat. Followed their [walkthrough](https://rstudio.github.io/packrat/walkthrough.html) docs, and 

```R
> library(packrat)
> packrat::status()
> packrat::init()
```

Downloads all sources locally, without committing them. Once new libraries are installed, we can just status&snapshot.

RStudio should display in the project properties that it has packrat enabled too.

Feel free to check out this branch first, before merging, if you have time to play, or interest, in using packrat :tada: I wonder if that works OK in other envs like Mac & Win. I'm on Ubuntu LTS, using only CRAN packages.

Cheers
Bruno