### PR TITLE
Map performance enhancements

### DIFF
--- a/constants_and_paths.R
+++ b/constants_and_paths.R
@@ -6,5 +6,5 @@ wind_file <- "windPH2.shp"
 latlon_CRS <- "+proj=longlat +datum=WGS84"
 NZTM_CRS <- "+init=epsg:2193"
 
-binpal <- colorBin(c("Green","Orange","Red"),c(0,140), 8, 
+binpal <- colorBin(c("Green","Orange","Red"), c(-10,140), 8, 
                    pretty = TRUE, na.color = "#00000000")

--- a/server.R
+++ b/server.R
@@ -165,8 +165,6 @@ server <- function(input, output, session){
   # })
   ### barplot ######
   output$myPlot <- renderPlot({
-    invalidateLater(5000,session)
-    
     barplot(subsetData()$PM2_5,
             main = "ODIN Readings",
             xlab = "ODIN ID",
@@ -181,9 +179,6 @@ server <- function(input, output, session){
   
   ###### plotly output ####
   output$plotly <-renderPlotly({
-    invalidateLater(5000,session)
-    
-    
     ##secondary y-axis definition.
     second_axis <- list(
       tickfont = list(color = "#636363"),
@@ -218,8 +213,7 @@ server <- function(input, output, session){
   
   
   ## ODIN dynamic map.####
-  observe({
-    
+  observeEvent(eventExpr = input$timeRange, ignoreNULL = T, handlerExpr = {
     leafletProxy('myMap', deferUntilFlush = FALSE) %>%
       addProviderTiles(providers$Stamen.Toner, group = "Toner",
                        options = providerTileOptions(opacity = 1)) %>%
@@ -227,7 +221,9 @@ server <- function(input, output, session){
                options = tileOptions(opacity = 1)) %>%
       addProviderTiles(providers$Stamen.TonerLite, group = "Toner Lite",
                        options = providerTileOptions(opacity = 1)) %>%
-      clearGroup('Wind') %>%
+      clearImages() %>%
+      clearMarkers() %>%
+      clearShapes() %>%
       addRasterImage(subsetRaster(),
                      group = "PM2.5(interpolated)",
                      colors = binpal,


### PR DESCRIPTION
The change in constants_and_paths.R is to remove an error where we had values
being requested that were outside the available range, resulting in an error.

I noticed an increase in the memory used by the application whenever that error
occurred. I believe objects are being discarded, and shiny is allocating new ones, which results
in heap pollution, and a memory leak over time.

Below screenshot before the patch.

![before](https://user-images.githubusercontent.com/304786/40902993-fa2b9316-6829-11e8-9f9c-aacd304c0f4f.png)

In server.R the invalidateLater calls were removed, as the objects are being
updated via events already.

Also, I noticed that markers were piling up on top of each other. Even though we cleared the
'Wind' group, we never cleared other elements. For each 'tick' we now clear all images,
markers, and also the shapes. Leaving only the base layer and control elements.

Before this change, I was getting multiple warnings, and the server memory was going well
above 500 MB. After, I got consistent results, where it did not reach 500MB, and I could
see the garbage collection doing its job, with the memory going down to around 100MB
sometimes.

![after](https://user-images.githubusercontent.com/304786/40903007-0943e060-682a-11e8-8e59-3b8358d857fa.png)
